### PR TITLE
Assume role for reading files off S3

### DIFF
--- a/ftp-upload/cloudformation.yaml
+++ b/ftp-upload/cloudformation.yaml
@@ -38,9 +38,6 @@ Parameters:
       - 'true'
       - 'false'
     Default: 'false'
-  AthenaRole:
-    Description: Role to assume in order to query Athena
-    Type: String
   SourceBucketName:
     Description: Bucket where NLA files are generated
     Type: String
@@ -73,7 +70,6 @@ Resources:
           FtpUser: !Ref FtpUser
           FtpPassword: !Ref FtpPassword
           ZipFile: !Ref ZipFile
-          AthenaRole: !Ref AthenaRole
           Stage: !Ref Stage
       CodeUri:
         Bucket: !Ref DeployBucket

--- a/ftp-upload/cloudformation.yaml
+++ b/ftp-upload/cloudformation.yaml
@@ -21,6 +21,10 @@ Parameters:
     Description: Bucket to copy files to
     Type: String
     Default: content-api-dist
+  SourceBucket:
+    Description: Bucket where CSV files are uploaded
+    Type: String
+    Default: nla-analytics
   FtpHost:
     Description: Hostname of the ftp server to upload to
     Type: String
@@ -65,6 +69,12 @@ Resources:
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}/${App}.zip
+      Events:
+        AthenaCSVEvent:
+          Type: S3
+          Properties:
+            Bucket: !Ref SrcBucket
+            Events: s3:ObjectCreated:*
       Policies:
         - AWSLambdaBasicExecutionRole
         - Statement:

--- a/ftp-upload/cloudformation.yaml
+++ b/ftp-upload/cloudformation.yaml
@@ -46,6 +46,18 @@ Parameters:
     Type: String
     Default: nla-analytics
 Resources:
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      ManagedPolicyArns: 
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service:
+                - lambda.amazonaws.com
   Lambda:
     Type: AWS::Serverless::Function
     Properties:
@@ -72,8 +84,8 @@ Resources:
           Properties:
             Bucket: !Ref SourceBucket
             Events: s3:ObjectCreated:*
-      Policies:
-        - AWSLambdaBasicExecutionRole
+      Role: !GetAtt ExecutionRole.Arn
+  
   SourceBucket:
     Type: AWS::S3::Bucket
     Properties:

--- a/ftp-upload/cloudformation.yaml
+++ b/ftp-upload/cloudformation.yaml
@@ -74,13 +74,6 @@ Resources:
             Events: s3:ObjectCreated:*
       Policies:
         - AWSLambdaBasicExecutionRole
-        - Statement:
-            Effect: Allow
-            Action:
-              - s3:GetObject
-              - s3:ListObjects
-            Resource:
-              !Ref SourceBucket
   SourceBucket:
     Type: AWS::S3::Bucket
     Properties:

--- a/ftp-upload/cloudformation.yaml
+++ b/ftp-upload/cloudformation.yaml
@@ -38,6 +38,9 @@ Parameters:
       - 'true'
       - 'false'
     Default: 'false'
+  AthenaRole:
+    Description: Role to assume in order to query Athena
+    Type: String
   SourceBuckets:
     Description: List of the source bucket ARN permissions, e.g. 'arn:aws:s3::*:my-source-bucket-1/*,arn:aws:s3::*:my-source-bucket-2/*'
     Type: CommaDelimitedList
@@ -57,6 +60,7 @@ Resources:
           FtpUser: !Ref FtpUser
           FtpPassword: !Ref FtpPassword
           ZipFile: !Ref ZipFile
+          AthenaRole: !Ref AthenaRole
           Stage: !Ref Stage
       CodeUri:
         Bucket: !Ref DeployBucket

--- a/ftp-upload/cloudformation.yaml
+++ b/ftp-upload/cloudformation.yaml
@@ -21,10 +21,6 @@ Parameters:
     Description: Bucket to copy files to
     Type: String
     Default: content-api-dist
-  SourceBucket:
-    Description: Bucket where CSV files are uploaded
-    Type: String
-    Default: nla-analytics
   FtpHost:
     Description: Hostname of the ftp server to upload to
     Type: String
@@ -73,7 +69,7 @@ Resources:
         AthenaCSVEvent:
           Type: S3
           Properties:
-            Bucket: !Ref SrcBucket
+            Bucket: !Ref SourceBuckets
             Events: s3:ObjectCreated:*
       Policies:
         - AWSLambdaBasicExecutionRole

--- a/ftp-upload/cloudformation.yaml
+++ b/ftp-upload/cloudformation.yaml
@@ -41,9 +41,10 @@ Parameters:
   AthenaRole:
     Description: Role to assume in order to query Athena
     Type: String
-  SourceBuckets:
-    Description: List of the source bucket ARN permissions, e.g. 'arn:aws:s3::*:my-source-bucket-1/*,arn:aws:s3::*:my-source-bucket-2/*'
-    Type: CommaDelimitedList
+  SourceBucketName:
+    Description: Bucket where NLA files are generated
+    Type: String
+    Default: nla-analytics
 Resources:
   Lambda:
     Type: AWS::Serverless::Function
@@ -69,7 +70,7 @@ Resources:
         AthenaCSVEvent:
           Type: S3
           Properties:
-            Bucket: !Ref SourceBuckets
+            Bucket: !Ref SourceBucket
             Events: s3:ObjectCreated:*
       Policies:
         - AWSLambdaBasicExecutionRole
@@ -79,4 +80,8 @@ Resources:
               - s3:GetObject
               - s3:ListObjects
             Resource:
-              !Ref SourceBuckets
+              !Ref SourceBucket
+  SourceBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Ref SourceBucketName

--- a/ftp-upload/src/config.ts
+++ b/ftp-upload/src/config.ts
@@ -3,5 +3,4 @@ export class Config {
     FtpUser: string = process.env.FtpUser;
     FtpPassword: string = process.env.FtpPassword;
     ZipFile: boolean = process.env.ZipFile.toLowerCase() === "true";
-    AthenaRole: string = process.env.AthenaRole;
 }

--- a/ftp-upload/src/config.ts
+++ b/ftp-upload/src/config.ts
@@ -3,4 +3,5 @@ export class Config {
     FtpUser: string = process.env.FtpUser;
     FtpPassword: string = process.env.FtpPassword;
     ZipFile: boolean = process.env.ZipFile.toLowerCase() === "true";
+    AthenaRole: string = process.env.AthenaRole;
 }

--- a/ftp-upload/src/lambda.ts
+++ b/ftp-upload/src/lambda.ts
@@ -5,34 +5,13 @@ let AWS = require('aws-sdk');
 let ftp = require('ftp');
 let fs = require('fs');
 let archiver = require('archiver');
-const sts = new AWS.STS();
 
 let config = new Config();
 
 export async function handler(event) {
-    console.log(`Assuming role...`);
-    return new Promise((resolve, reject) =>  {
-        sts.assumeRole({
-            RoleArn: config.AthenaRole,
-            RoleSessionName: "S3toFTP"
-        }, getCredentials(event, resolve, reject))
-    });
-}    
-
-const getCredentials = (event, resolve, reject) => (err, data) => {
-    if (err) {
-        reject(new Error(err));
-    } else {
-        console.log("Got credentials", data);
-        processRecords(event, data.Credentials).then(resolve);
-    }
-}
-
-const processRecords = (event, credentials) => {
     const s3 = new AWS.S3({
         apiVersion: 'latest',
         region: 'eu-west-1', 
-        credentials
     });
 
     return Promise.all(

--- a/ftp-upload/src/lambda.ts
+++ b/ftp-upload/src/lambda.ts
@@ -15,7 +15,7 @@ export async function handler(event) {
         RoleSessionName: 'capi'
     }));
     chain.providers.unshift(() => new AWS.SharedIniFileCredentials({ profile: 'capi' }))
-    chain.resolvePromise
+    chain.resolvePromise()
         .then(credentials => new AWS.S3({
             apiVersion: 'latest',
             region: 'eu-west-1', 

--- a/ftp-upload/src/lambda.ts
+++ b/ftp-upload/src/lambda.ts
@@ -11,17 +11,20 @@ let config = new Config();
 
 export async function handler(event) {
     console.log(`Assuming role...`);
-    sts.assumeRole({
-        RoleArn: config.AthenaRole,
-        RoleSessionName: "S3toFTP"
-    }, getCredentials(event))    
+    return new Promise((resolve, reject) =>  {
+        sts.assumeRole({
+            RoleArn: config.AthenaRole,
+            RoleSessionName: "S3toFTP"
+        }, getCredentials(event, resolve, reject))
+    });
 }    
 
-const getCredentials = event => (err, data) => {
+const getCredentials = (event, resolve, reject) => (err, data) => {
     if (err) {
-        console.error(err, err.stack);
+        reject(new Error(err));
     } else {
-        processRecords(event, data.Credentials);
+        console.log("Got credentials", data);
+        processRecords(event, data.Credentials).then(resolve);
     }
 }
 

--- a/ftp-upload/src/lambda.ts
+++ b/ftp-upload/src/lambda.ts
@@ -9,12 +9,14 @@ let archiver = require('archiver');
 let config = new Config();
 
 export async function handler(event) {
-    const chain = new AWS.CredentialProviderChain();
-    chain.providers.unshift(() => new AWS.TemporaryCredentials({
-        RoleArn: config.AthenaRole,
-        RoleSessionName: 'capi'
-    }));
-    chain.providers.unshift(() => new AWS.SharedIniFileCredentials({ profile: 'capi' }))
+    const chain = new AWS.CredentialProviderChain([
+        new AWS.TemporaryCredentials({
+            RoleArn: config.AthenaRole,
+            RoleSessionName: 'capi'
+        }),
+        new AWS.SharedIniFileCredentials({ profile: 'capi' })
+    ]);
+
     chain.resolvePromise()
         .then(credentials => new AWS.S3({
             apiVersion: 'latest',

--- a/ftp-upload/src/lambda.ts
+++ b/ftp-upload/src/lambda.ts
@@ -12,7 +12,8 @@ let config = new Config();
 export async function handler(event) {
     console.log(`Assuming role...`);
     sts.assumeRole({
-        RoleArn: config.AthenaRole
+        RoleArn: config.AthenaRole,
+        RoleSessionName: "S3toFTP"
     }, getCredentials(event))    
 }    
 


### PR DESCRIPTION
Files generated by Athena can only be read by entities having the right permissions, given to them by a role defined in the Ophan account.