### PR TITLE
Naming convention for NLA

### DIFF
--- a/ftp-upload/cloudformation.yaml
+++ b/ftp-upload/cloudformation.yaml
@@ -42,6 +42,9 @@ Parameters:
     Description: Bucket where NLA files are generated
     Type: String
     Default: nla-analytics
+  AthenaRole:
+    Description: Role to assume in order to read files produced by Athena
+    Type: String
 Resources:
   ExecutionRole:
     Type: AWS::IAM::Role
@@ -71,6 +74,7 @@ Resources:
           FtpPassword: !Ref FtpPassword
           ZipFile: !Ref ZipFile
           Stage: !Ref Stage
+          AthenaRole: !Ref AthenaRole
       CodeUri:
         Bucket: !Ref DeployBucket
         Key: !Sub ${Stack}/${Stage}/${App}/${App}.zip

--- a/ftp-upload/cloudformation.yaml
+++ b/ftp-upload/cloudformation.yaml
@@ -66,34 +66,33 @@ Resources:
               Effect: Allow
               Action: sts:AssumeRole
               Resource: !Ref AthenaRole
-Lambda:
-    Type: AWS::Serverless::Function
-    Properties:
-      FunctionName: !Sub ${App}-${Stage}
-      Description: Copies new s3 objects to an ftp server
-      Runtime: nodejs8.10
-      Handler: lambda.handler
-      MemorySize: 128
-      Timeout: 300
-      Environment:
-        Variables:
-          FtpHost: !Ref FtpHost
-          FtpUser: !Ref FtpUser
-          FtpPassword: !Ref FtpPassword
-          ZipFile: !Ref ZipFile
-          Stage: !Ref Stage
-          AthenaRole: !Ref AthenaRole
-      CodeUri:
-        Bucket: !Ref DeployBucket
-        Key: !Sub ${Stack}/${Stage}/${App}/${App}.zip
-      Events:
-        AthenaCSVEvent:
-          Type: S3
-          Properties:
-            Bucket: !Ref SourceBucket
-            Events: s3:ObjectCreated:*
-      Role: !GetAtt ExecutionRole.Arn
-  
+  Lambda:
+      Type: AWS::Serverless::Function
+      Properties:
+        FunctionName: !Sub ${App}-${Stage}
+        Description: Copies new s3 objects to an ftp server
+        Runtime: nodejs8.10
+        Handler: lambda.handler
+        MemorySize: 128
+        Timeout: 300
+        Environment:
+          Variables:
+            FtpHost: !Ref FtpHost
+            FtpUser: !Ref FtpUser
+            FtpPassword: !Ref FtpPassword
+            ZipFile: !Ref ZipFile
+            Stage: !Ref Stage
+            AthenaRole: !Ref AthenaRole
+        CodeUri:
+          Bucket: !Ref DeployBucket
+          Key: !Sub ${Stack}/${Stage}/${App}/${App}.zip
+        Events:
+          AthenaCSVEvent:
+            Type: S3
+            Properties:
+              Bucket: !Ref SourceBucket
+              Events: s3:ObjectCreated:*
+        Role: !GetAtt ExecutionRole.Arn
   SourceBucket:
     Type: AWS::S3::Bucket
     Properties:

--- a/ftp-upload/cloudformation.yaml
+++ b/ftp-upload/cloudformation.yaml
@@ -58,7 +58,15 @@ Resources:
             Principal:
               Service:
                 - lambda.amazonaws.com
-  Lambda:
+      Path: /
+      Policies:
+        - PolicyName: assume-athena-query
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action: sts:AssumeRole
+              Resource: !Ref AthenaRole
+Lambda:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub ${App}-${Stage}

--- a/ftp-upload/package.json
+++ b/ftp-upload/package.json
@@ -6,7 +6,7 @@
   "buildDir": "./target",
   "riffraffFile": "./riff-raff.yaml",
   "dependencies": {
-    "aws-sdk": "^2.264.1",
+    "aws-sdk": "^2.384.0",
     "typescript": "2.8.3",
     "moment": "2.22.2",
     "ftp": "0.3.10",

--- a/ftp-upload/src/config.ts
+++ b/ftp-upload/src/config.ts
@@ -3,4 +3,5 @@ export class Config {
     FtpUser: string = process.env.FtpUser;
     FtpPassword: string = process.env.FtpPassword;
     ZipFile: boolean = process.env.ZipFile.toLowerCase() === "true";
+    AthenaRole: string = process.env.AthenaRole;
 }

--- a/ftp-upload/src/lambda.ts
+++ b/ftp-upload/src/lambda.ts
@@ -111,9 +111,9 @@ function streamS3ToLocalZip(bucket: string, key: string): Promise<string> {
             Key: key
         }).createReadStream();
 
-        const output = `/tmp/${key}.zip`;
+        const outputFile = `/tmp/${key}.zip`;
 
-        const output = fs.createWriteStream(output);
+        const output = fs.createWriteStream(outputFile);
         const archive = archiver('zip');
 
         archive.pipe(output);
@@ -122,7 +122,7 @@ function streamS3ToLocalZip(bucket: string, key: string): Promise<string> {
         archive.finalize();
 
         stream.on('end', () => {
-            resolve(output);
+            resolve(outputFile);
         });
 
         stream.on('error', (err: Error) => {

--- a/ftp-upload/src/lambda.ts
+++ b/ftp-upload/src/lambda.ts
@@ -16,7 +16,8 @@ export async function handler(event) {
             RoleArn: config.AthenaRole,
             RoleSessionName: 'ophan'
         }, (err, data) => {
-            console.dir(arguments);
+            console.dir(err)
+            console.dir(data)
             if (err) reject(err);
             resolve(data.Credentials);
         });

--- a/ftp-upload/src/lambda.ts
+++ b/ftp-upload/src/lambda.ts
@@ -24,14 +24,14 @@ export async function handler(event) {
                     secretAccessKey: data.Credentials.SecretAccessKey,
                     sessionToken: data.Credentials.SessionToken
                 });
-                resolve(data.Credentials);
+                resolve(event);
             }
         });
-    }).then(run.bind(null, event));
+    }).then(run);
 }
 
-async function run(event, ophanCreds) {
-    const s3 = new AWS.S3({ credentials: ophanCreds });
+async function run(event) {
+    const s3 = new AWS.S3();
 
     return Promise.all(event.Records
         .filter(record => record.s3.object.key.endsWith('csv'))

--- a/ftp-upload/src/lambda.ts
+++ b/ftp-upload/src/lambda.ts
@@ -39,10 +39,13 @@ async function run(event) {
         .map(record => {
             const bucket = record.s3.bucket.name;
             const key = record.s3.object.key;
-            const today = new Date();
-            today.setDate(today.getDate() - 1);
-            const yesterday = `${today.getFullYear()}${pad(today.getMonth() + 1)}${pad(today.getDate())}`;
-            const dst = `theguardian_${yesterday}.${config.ZipFile ? 'zip' : 'csv'}`;
+            const yesterday = new Date();
+            // this is how you do date math in js: just add or substract whichever field is necessary
+            yesterday.setDate(yesterday.getDate() - 1);
+            // produce YYYYMMDD (months are zero-indexed in js)
+            const yesterdayStr = `${yesterday.getFullYear()}${pad(yesterday.getMonth() + 1)}${pad(yesterday.getDate())}`;
+            // produce theguardian_YYYYMMDD.FF where FF is either zip or csv
+            const dst = `theguardian_${yesterdayStr}.${config.ZipFile ? 'zip' : 'csv'}`;
             console.log(`Streaming ${bucket}/${key} to ${dst}`);
 
             if (config.ZipFile) {

--- a/ftp-upload/src/lambda.ts
+++ b/ftp-upload/src/lambda.ts
@@ -11,6 +11,7 @@ const sts = new AWS.STS();
 
 export async function handler(event) {
     return new Promise((resolve, reject) => {
+        console.log(`Assuming role ${config.AthenaRole}`)
         sts.assumeRole({
             RoleArn: config.AthenaRole,
             RoleSessionName: 'ophan'

--- a/ftp-upload/src/lambda.ts
+++ b/ftp-upload/src/lambda.ts
@@ -18,7 +18,8 @@ export async function handler(event) {
                 const bucket = record.s3.bucket.name;
                 const key = record.s3.object.key;
                 const today = new Date();
-                const yesterday = `${today.getFullYear()}${today.getMonth() + 1}${today.getDate() - 1}`;
+                today.setDate(today.getDate() - 1);
+                const yesterday = `${today.getFullYear()}${today.getMonth() + 1}${today.getDate()}`;
                 const dst = `theguardian_${yesterday}.${config.ZipFile ? 'zip' : 'csv'}`;
                 console.log(`Streaming ${bucket}/${key} to ${dst}`);
 

--- a/ftp-upload/src/lambda.ts
+++ b/ftp-upload/src/lambda.ts
@@ -16,6 +16,7 @@ export async function handler(event) {
             RoleArn: config.AthenaRole,
             RoleSessionName: 'ophan'
         }, (err, data) => {
+            console.dir(arguments);
             if (err) reject(err);
             resolve(data.Credentials);
         });

--- a/ftp-upload/src/lambda.ts
+++ b/ftp-upload/src/lambda.ts
@@ -6,142 +6,155 @@ const ftp = require('ftp');
 const fs = require('fs');
 const archiver = require('archiver');
 
-const s3 = new AWS.S3();
 const config = new Config();
+const sts = new AWS.STS();
 
 export async function handler(event) {
-    return Promise.all(
-        event.Records
-            .filter(record => record.s3.object.key.endsWith('csv'))
-            .slice(0, 1)
-            .map(record => {
-                const bucket = record.s3.bucket.name;
-                const key = record.s3.object.key;
-                const today = new Date();
-                today.setDate(today.getDate() - 1);
-                const yesterday = `${today.getFullYear()}${pad(today.getMonth() + 1)}${pad(today.getDate())}`;
-                const dst = `theguardian_${yesterday}.${config.ZipFile ? 'zip' : 'csv'}`;
-                console.log(`Streaming ${bucket}/${key} to ${dst}`);
-
-                if (config.ZipFile) {
-                    return streamS3ToLocalZip(bucket, key)
-                        .then(fileName => 
-                            ftpConnect(config.FtpHost, config.FtpUser, config.FtpPassword)
-                                .then(ftpClient => streamLocalToFtp(fileName, dst, ftpClient))
-                        );
-                } else {
-                    return ftpConnect(config.FtpHost, config.FtpUser, config.FtpPassword)
-                        .then(ftpClient => streamS3FileToFtp(bucket, key, dst, ftpClient))
-                }
-            })
-    );
-}
-
-function pad(n: number): string {
-    return n.toString(10).padStart(2, '0');
-}
-
-/**
- * Creates a new ftp connection and returns the ftp client.
- */
-function ftpConnect(host: string, user: string, password: string): Promise<any> {
     return new Promise((resolve, reject) => {
-        const ftpClient = new ftp();
-
-        ftpClient.connect({
-            host,
-            user,
-            password
+        sts.assumeRole({
+            RoleArn: config.AthenaRole,
+            RoleSessionName: 'ophan'
+        }, (err, data) => {
+            if (err) reject(err);
+            resolve(data.Credentials);
         });
-
-        ftpClient.on('ready', () => {
-            resolve(ftpClient)
-        });
-        ftpClient.on('error', (err) => {
-            console.log("FTP error: ", err);
-            reject(err)
-        });
-    })
+    }).then(run.bind(null, event));
 }
 
-/**
- * Pipes the stream to the ftp session under the given path.
- */
-function streamToFtp(stream: Readable, path: string, ftpClient): Promise<string> {
-    return new Promise((resolve, reject) => {
-        stream.on('readable', () => {
-            ftpClient.put(stream, path, (err) => {
-                if (err) {
-                    console.log(`Error writing ${path} to ftp`, err);
-                    reject(err)
-                }
-            })
-        });
+async function run(event, ophanCreds) {
+    const s3 = new AWS.S3(ophanCreds);
 
-        stream.on('end', () => {
-            resolve(path)
-        });
+    return Promise.all(event.Records
+        .filter(record => record.s3.object.key.endsWith('csv'))
+        .slice(0, 1)
+        .map(record => {
+            const bucket = record.s3.bucket.name;
+            const key = record.s3.object.key;
+            const today = new Date();
+            today.setDate(today.getDate() - 1);
+            const yesterday = `${today.getFullYear()}${pad(today.getMonth() + 1)}${pad(today.getDate())}`;
+            const dst = `theguardian_${yesterday}.${config.ZipFile ? 'zip' : 'csv'}`;
+            console.log(`Streaming ${bucket}/${key} to ${dst}`);
 
-        stream.on('error', (err: Error) => {
-            console.log(`Error streaming ${path} to ftp`, err);
-            reject(err)
-        });
-    })
-}
+            if (config.ZipFile) {
+                return streamS3ToLocalZip(bucket, key)
+                    .then(fileName => 
+                        ftpConnect(config.FtpHost, config.FtpUser, config.FtpPassword)
+                            .then(ftpClient => streamLocalToFtp(fileName, dst, ftpClient))
+                    );
+            } else {
+                return ftpConnect(config.FtpHost, config.FtpUser, config.FtpPassword)
+                    .then(ftpClient => streamS3FileToFtp(bucket, key, dst, ftpClient))
+            }
+        })
+    )
 
-/**
- * Streams the given s3 object to the given ftp session.
- */
-function streamS3FileToFtp(bucket: string, key: string, dst: string, ftpClient): Promise<string> {
-    const stream: Readable = s3.getObject({
-        Bucket: bucket,
-        Key: key
-    }).createReadStream();
+    /**
+     * Creates a new ftp connection and returns the ftp client.
+     */
+    function ftpConnect(host: string, user: string, password: string): Promise<any> {
+        return new Promise((resolve, reject) => {
+            const ftpClient = new ftp();
 
-    return streamToFtp(stream, dst, ftpClient)
-}
+            ftpClient.connect({
+                host,
+                user,
+                password
+            });
 
-/**
- * Streams the given s3 object to a local zip archive.
- */
-function streamS3ToLocalZip(bucket: string, key: string): Promise<string> {
-    return new Promise((resolve, reject) => {
+            ftpClient.on('ready', () => {
+                resolve(ftpClient)
+            });
+            ftpClient.on('error', (err) => {
+                console.log("FTP error: ", err);
+                reject(err)
+            });
+        })
+    }
+
+    /**
+     * Pipes the stream to the ftp session under the given path.
+     */
+    function streamToFtp(stream: Readable, path: string, ftpClient): Promise<string> {
+        return new Promise((resolve, reject) => {
+            stream.on('readable', () => {
+                ftpClient.put(stream, path, (err) => {
+                    if (err) {
+                        console.log(`Error writing ${path} to ftp`, err);
+                        reject(err)
+                    }
+                })
+            });
+
+            stream.on('end', () => {
+                resolve(path)
+            });
+
+            stream.on('error', (err: Error) => {
+                console.log(`Error streaming ${path} to ftp`, err);
+                reject(err)
+            });
+        })
+    }
+
+    /**
+     * Streams the given s3 object to the given ftp session.
+     */
+    function streamS3FileToFtp(bucket: string, key: string, dst: string, ftpClient): Promise<string> {
         const stream: Readable = s3.getObject({
             Bucket: bucket,
             Key: key
         }).createReadStream();
 
-        const outputFile = `/tmp/${key}.zip`;
+        return streamToFtp(stream, dst, ftpClient)
+    }
 
-        const output = fs.createWriteStream(outputFile);
-        const archive = archiver('zip');
+    /**
+     * Streams the given s3 object to a local zip archive.
+     */
+    function streamS3ToLocalZip(bucket: string, key: string): Promise<string> {
+        return new Promise((resolve, reject) => {
+            const stream: Readable = s3.getObject({
+                Bucket: bucket,
+                Key: key
+            }).createReadStream();
 
-        archive.pipe(output);
+            const outputFile = `/tmp/${key}.zip`;
 
-        archive.append(stream, { name: key });
-        archive.finalize();
+            const output = fs.createWriteStream(outputFile);
+            const archive = archiver('zip');
 
-        stream.on('end', () => {
-            resolve(outputFile);
-        });
+            archive.pipe(output);
 
-        stream.on('error', (err: Error) => {
-            console.log(`Error streaming ${key} to archive`, err);
-            reject(err);
-        });
+            archive.append(stream, { name: key });
+            archive.finalize();
 
-        archive.on('error', (err) => {
-            console.log(`Error archiving ${key}`, err);
-            reject(err);
-        });
-    })
+            stream.on('end', () => {
+                resolve(outputFile);
+            });
+
+            stream.on('error', (err: Error) => {
+                console.log(`Error streaming ${key} to archive`, err);
+                reject(err);
+            });
+
+            archive.on('error', (err) => {
+                console.log(`Error archiving ${key}`, err);
+                reject(err);
+            });
+        })
+    }
+
+    /**
+     * Streams the given local file to the given ftp session.
+     */
+    function streamLocalToFtp(path: string, dst: string, ftpClient): Promise<string> {
+        const stream = fs.createReadStream(path);
+
+        return streamToFtp(stream, dst, ftpClient)
+    }
 }
 
-/**
- * Streams the given local file to the given ftp session.
- */
-function streamLocalToFtp(path: string, dst: string, ftpClient): Promise<string> {
-    const stream = fs.createReadStream(path);
-
-    return streamToFtp(stream, dst, ftpClient)
+function pad(n: number): string {
+    return n.toString(10).padStart(2, '0');
 }

--- a/ftp-upload/src/lambda.ts
+++ b/ftp-upload/src/lambda.ts
@@ -25,7 +25,7 @@ export async function handler(event) {
 }
 
 async function run(event, ophanCreds) {
-    const s3 = new AWS.S3(ophanCreds);
+    const s3 = new AWS.S3({ credentials: ophanCreds });
 
     return Promise.all(event.Records
         .filter(record => record.s3.object.key.endsWith('csv'))

--- a/ftp-upload/src/lambda.ts
+++ b/ftp-upload/src/lambda.ts
@@ -15,7 +15,7 @@ export async function handler(event) {
             const bucket = record.s3.bucket.name;
             const key = record.s3.object.key;
             const dst = key;
-            console.log(`Streaming ${bucket}/${key}`);
+            console.log(`Streaming ${bucket}/${key} to ${dst}`);
 
             if (config.ZipFile) {
                 return streamS3ToLocalZip(bucket, key)

--- a/ftp-upload/src/lambda.ts
+++ b/ftp-upload/src/lambda.ts
@@ -7,7 +7,7 @@ const fs = require('fs');
 const archiver = require('archiver');
 
 const config = new Config();
-const sts = new AWS.STS();
+const sts = new AWS.STS({ apiVersion: '2011-06-15' });
 
 export async function handler(event) {
     return new Promise((resolve, reject) => {

--- a/ftp-upload/src/lambda.ts
+++ b/ftp-upload/src/lambda.ts
@@ -18,8 +18,14 @@ export async function handler(event) {
         }, (err, data) => {
             if (err) 
                 reject(err);
-            else
+            else {
+                AWS.config.update({
+                    accessKeyId: data.Credentials.AccessKeyId,
+                    secretAccessKey: data.Credentials.SecretAccessKey,
+                    sessionToken: data.Credentials.SessionToken
+                });
                 resolve(data.Credentials);
+            }
         });
     }).then(run.bind(null, event));
 }

--- a/ftp-upload/src/lambda.ts
+++ b/ftp-upload/src/lambda.ts
@@ -19,7 +19,7 @@ export async function handler(event) {
                 const key = record.s3.object.key;
                 const today = new Date();
                 today.setDate(today.getDate() - 1);
-                const yesterday = `${today.getFullYear()}${today.getMonth() + 1}${today.getDate()}`;
+                const yesterday = `${today.getFullYear()}${pad(today.getMonth() + 1)}${pad(today.getDate())}`;
                 const dst = `theguardian_${yesterday}.${config.ZipFile ? 'zip' : 'csv'}`;
                 console.log(`Streaming ${bucket}/${key} to ${dst}`);
 
@@ -33,6 +33,10 @@ export async function handler(event) {
                 }
             })
     );
+}
+
+function pad(n: number): string {
+    return n.toString(10).padStart(2, '0');
 }
 
 /**

--- a/ftp-upload/src/lambda.ts
+++ b/ftp-upload/src/lambda.ts
@@ -16,10 +16,10 @@ export async function handler(event) {
             RoleArn: config.AthenaRole,
             RoleSessionName: 'ophan'
         }, (err, data) => {
-            console.dir(err)
-            console.dir(data)
-            if (err) reject(err);
-            resolve(data.Credentials);
+            if (err) 
+                reject(err);
+            else
+                resolve(data.Credentials);
         });
     }).then(run.bind(null, event));
 }

--- a/nla-job/cloudformation.yaml
+++ b/nla-job/cloudformation.yaml
@@ -1,5 +1,5 @@
-AWSTemplateFormatVersion: '2010-09-09'
-Transform: 'AWS::Serverless-2016-10-31'
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: "AWS::Serverless-2016-10-31"
 Description: Runs the NLA query in Athena which will store results in one of our S3 buckets
 
 Parameters:
@@ -38,7 +38,7 @@ Resources:
   ExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      ManagedPolicyArns: 
+      ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       AssumeRolePolicyDocument:
         Statement:


### PR DESCRIPTION
This update:

- makes sure we process only one CSV file per day
- uploads the result to a file named according to the pattern `theguardian_<yyyymmdd>.<format>`