### PR TITLE
Use the filename pattern inside the archive too

### DIFF
--- a/ftp-upload/cloudformation.yaml
+++ b/ftp-upload/cloudformation.yaml
@@ -31,13 +31,6 @@ Parameters:
     Description: Ftp password
     Type: String
     NoEcho: true
-  ZipFile:
-    Description: True if file should be zipped before uploading to ftp
-    Type: String
-    AllowedValues:
-      - 'true'
-      - 'false'
-    Default: 'false'
   SourceBucketName:
     Description: Bucket where NLA files are generated
     Type: String

--- a/ftp-upload/cloudformation.yaml
+++ b/ftp-upload/cloudformation.yaml
@@ -73,7 +73,6 @@ Resources:
             FtpHost: !Ref FtpHost
             FtpUser: !Ref FtpUser
             FtpPassword: !Ref FtpPassword
-            ZipFile: !Ref ZipFile
             Stage: !Ref Stage
             AthenaRole: !Ref AthenaRole
         CodeUri:

--- a/ftp-upload/src/config.ts
+++ b/ftp-upload/src/config.ts
@@ -2,6 +2,5 @@ export class Config {
     FtpHost: string = process.env.FtpHost;
     FtpUser: string = process.env.FtpUser;
     FtpPassword: string = process.env.FtpPassword;
-    ZipFile: boolean = process.env.ZipFile.toLowerCase() === "true";
     AthenaRole: string = process.env.AthenaRole;
 }

--- a/ftp-upload/src/lambda.ts
+++ b/ftp-upload/src/lambda.ts
@@ -46,7 +46,7 @@ async function run(event) {
             const dst = `theguardian_${yesterday.getFullYear()}${pad(yesterday.getMonth() + 1)}${pad(yesterday.getDate())}`;
             console.log(`Streaming ${bucket}/${key} to ${dst}.zip`);
 
-            return streamS3ToLocalZip(bucket, key, dst)
+            return streamS3ToLocalZip(bucket, key, `${dst}.csv`)
                 .then(fileName => 
                     ftpConnect(config.FtpHost, config.FtpUser, config.FtpPassword)
                         .then(ftpClient => streamLocalToFtp(fileName, `${dst}.zip`, ftpClient))
@@ -119,7 +119,7 @@ async function run(event) {
 
             archive.pipe(output);
 
-            archive.append(stream, { name: `${dst}.csv` });
+            archive.append(stream, { name: dst });
             archive.finalize();
 
             stream.on('end', () => {

--- a/ftp-upload/src/lambda.ts
+++ b/ftp-upload/src/lambda.ts
@@ -43,13 +43,13 @@ async function run(event) {
             // this is how you do date math in js: just add or substract whichever field is necessary
             yesterday.setDate(yesterday.getDate() - 1);
             // produce theguardian_YYYYMMDD (months are zero-indexed in js)
-            const dst = `theguardian_${yesterday.getFullYear()}${pad(yesterday.getMonth() + 1)}${pad(yesterday.getDate())}`;
-            console.log(`Streaming ${bucket}/${key} to ${dst}.zip`);
+            const destinationPath = `theguardian_${yesterday.getFullYear()}${pad(yesterday.getMonth() + 1)}${pad(yesterday.getDate())}`;
+            console.log(`Streaming ${bucket}/${key} to ${destinationPath}.zip`);
 
-            return streamS3ToLocalZip(bucket, key, `${dst}.csv`)
+            return streamS3ToLocalZip(bucket, key, `${destinationPath}.csv`)
                 .then(fileName => 
                     ftpConnect(config.FtpHost, config.FtpUser, config.FtpPassword)
-                        .then(ftpClient => streamLocalToFtp(fileName, `${dst}.zip`, ftpClient))
+                        .then(ftpClient => streamLocalToFtp(fileName, `${destinationPath}.zip`, ftpClient))
                 );
         })
     )

--- a/ftp-upload/src/lambda.ts
+++ b/ftp-upload/src/lambda.ts
@@ -42,22 +42,15 @@ async function run(event) {
             const yesterday = new Date();
             // this is how you do date math in js: just add or substract whichever field is necessary
             yesterday.setDate(yesterday.getDate() - 1);
-            // produce YYYYMMDD (months are zero-indexed in js)
-            const yesterdayStr = `${yesterday.getFullYear()}${pad(yesterday.getMonth() + 1)}${pad(yesterday.getDate())}`;
-            // produce theguardian_YYYYMMDD.FF where FF is either zip or csv
-            const dst = `theguardian_${yesterdayStr}.${config.ZipFile ? 'zip' : 'csv'}`;
-            console.log(`Streaming ${bucket}/${key} to ${dst}`);
+            // produce theguardian_YYYYMMDD (months are zero-indexed in js)
+            const dst = `theguardian_${yesterday.getFullYear()}${pad(yesterday.getMonth() + 1)}${pad(yesterday.getDate())}`;
+            console.log(`Streaming ${bucket}/${key} to ${dst}.zip`);
 
-            if (config.ZipFile) {
-                return streamS3ToLocalZip(bucket, key)
-                    .then(fileName => 
-                        ftpConnect(config.FtpHost, config.FtpUser, config.FtpPassword)
-                            .then(ftpClient => streamLocalToFtp(fileName, dst, ftpClient))
-                    );
-            } else {
-                return ftpConnect(config.FtpHost, config.FtpUser, config.FtpPassword)
-                    .then(ftpClient => streamS3FileToFtp(bucket, key, dst, ftpClient))
-            }
+            return streamS3ToLocalZip(bucket, key, dst)
+                .then(fileName => 
+                    ftpConnect(config.FtpHost, config.FtpUser, config.FtpPassword)
+                        .then(ftpClient => streamLocalToFtp(fileName, `${dst}.zip`, ftpClient))
+                );
         })
     )
 
@@ -110,21 +103,9 @@ async function run(event) {
     }
 
     /**
-     * Streams the given s3 object to the given ftp session.
-     */
-    function streamS3FileToFtp(bucket: string, key: string, dst: string, ftpClient): Promise<string> {
-        const stream: Readable = s3.getObject({
-            Bucket: bucket,
-            Key: key
-        }).createReadStream();
-
-        return streamToFtp(stream, dst, ftpClient)
-    }
-
-    /**
      * Streams the given s3 object to a local zip archive.
      */
-    function streamS3ToLocalZip(bucket: string, key: string): Promise<string> {
+    function streamS3ToLocalZip(bucket: string, key: string, dst: string): Promise<string> {
         return new Promise((resolve, reject) => {
             const stream: Readable = s3.getObject({
                 Bucket: bucket,
@@ -138,7 +119,7 @@ async function run(event) {
 
             archive.pipe(output);
 
-            archive.append(stream, { name: key });
+            archive.append(stream, { name: `${dst}.csv` });
             archive.finalize();
 
             stream.on('end', () => {


### PR DESCRIPTION
Two things:

1- we _always_ zip the archive, the `ZipFile` config is unnecessary
2- the naming pattern `theguardian_YYYYMMDD` must be used both for the archive (with `.zip`) _and_ its content (with `.csv`)