### PR TITLE
Update the policy and bucket naming convention

### DIFF
--- a/nla-job/cloudformation.yaml
+++ b/nla-job/cloudformation.yaml
@@ -22,7 +22,7 @@ Parameters:
     Type: String
     Default: content-api-dist
   DestinationBucket:
-    Description: List of the source bucket ARN permissions, e.g. 'arn:aws:s3::*:my-source-bucket-1/*,arn:aws:s3::*:my-source-bucket-2/*'
+    Description: List of the source bucket ARN permissions, e.g. 'arn:aws:s3:::my-source-bucket-1'
     Type: String
   DestinationBucketURI:
     Description: Same as above but using the s3:// notation
@@ -60,7 +60,9 @@ Resources:
             Statement:
               Effect: Allow
               Action: s3:*
-              Resource: !Ref DestinationBucket
+              Resource: 
+                - !Sub ${DestinationBucket}
+                - !Sub ${DestinationBucket}/*
 
   Lambda:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
Two things to remember wrt S3 ARNs:

- the account id must be left out, no `*` either
- when referring to the bucket, the slash at the end must be left out too

Because of the two mistakes above, Athena (in the Ophan account) could not run properly.