### PR TITLE
Don't terminate early

### DIFF
--- a/ftp-upload/src/lambda.ts
+++ b/ftp-upload/src/lambda.ts
@@ -87,6 +87,10 @@ async function run(event) {
      */
     function streamToFtp(stream: Readable, path: string, ftpClient): Promise<string> {
         return new Promise((resolve, reject) => {
+            ftpClient.on('end', () => {
+                resolve(path);
+            });
+
             stream.on('readable', () => {
                 ftpClient.put(stream, path, (err) => {
                     if (err) {
@@ -94,7 +98,6 @@ async function run(event) {
                         reject(err)
                     } else {
                         ftpClient.end();
-                        resolve(path);
                     }
                 });
             });


### PR DESCRIPTION
Closing the FTP connection does not happen instantly, i.e. calling `ftpClient.end()` will only close the connection _after_ current operations are over. The problem is that by calling `resolve`, the lambda is terminated before the FTP upload may have had the chance to terminate.

To be on the safe-side, we must wait for the `"end"` event to trigger, which happens _after_ the connection has ended.