### PR TITLE
Return a promise for the Athena query

### DIFF
--- a/nla-job/src/lambda.ts
+++ b/nla-job/src/lambda.ts
@@ -61,9 +61,6 @@ export function runQuery(athena: any, when: Date) {
     }
   };
 
-  return athena.startQueryExecution(params, function(err, data) {
-    if (err) console.log(err, err.stack); // an error occurred
-    else     console.log(data);           // successful response
-  });
+  return athena.startQueryExecution(params).promise();
 }
 


### PR DESCRIPTION
Small fix which I hope will address a behaviour I've been seeing for the past few days: that the lambda runs perfectly fine locally but breaks online with a weird error message

```
Unable to stringify response body as json: Converting circular structure to JSON: TypeError at JSON.stringify (<anonymous>)
```

This is completely unhelpful. The only lead I got from AWS support was [this ticket](https://github.com/aws/aws-sdk-js/issues/2069) for a similar issue. There might be a problem with the internals of the aws SDK, I don't know.

The solution suggested is to never return the request, which is what I was doing previously (for no specific reason). So instead I'm returning a promise that will fulfill when the request is done, which is certainly more correct.